### PR TITLE
(feat, bug) Fixed Eslint absolute path issue and implemented settings have the logger at a stable point

### DIFF
--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -17,11 +17,12 @@ export const SETTINGS = {
          hint: "KNOWLEDGE-RECALLED.SETTINGS.DEBUG.hint",
          scope: "client",
          config: "true",
-         default: "INFO",
+         default: "ERROR",
+         requiresReload: true,
          type: String,
          choices: {
-            INFO: "INFO",
             ERROR: "ERROR",
+            INFO: "INFO",
             DEBUG: "DEBUG"
          },
       }

--- a/src/lib/debugger.js
+++ b/src/lib/debugger.js
@@ -5,7 +5,7 @@ let instance;
  */
 const logLevelStrings = {
    INFO: "INFO",
-   ERROR: "ERORR",
+   ERROR: "ERROR",
    DEBUG: "DEBUG"
 };
 
@@ -23,6 +23,8 @@ function validateLogLevel(level) {
 
 class Debugger {
    /**
+    * @param logLevel
+    *
     * @class
     */
    constructor() {
@@ -30,7 +32,7 @@ class Debugger {
          throw new Error("Only one debugger class is allowed");
       }
       instance = this;
-      this.logLevel = "";
+      this.logLevel;
       this.moduleInfo = "Knowledge Recalled:";
       this.sessionLog = [];
       this.count = {
@@ -45,6 +47,7 @@ class Debugger {
    setLogLevel(logLevel) {
       const validatedLogLevel = validateLogLevel(logLevel);
       this.logLevel = validatedLogLevel;
+      console.log(this.logLevel);
    }
 
    /**
@@ -55,7 +58,7 @@ class Debugger {
     * @returns {void}
     */
    info(...params) {
-      if (this.logLevel === "INFO" || this.logLevel === "DEBUG" || this.logLevel === "") {
+      if (this.logLevel === "INFO" || this.logLevel === "DEBUG" || this.logLevel === undefined) {
          const logInfo = `[INFO] ${this.getTime()} | ${this.moduleInfo}`;
          const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
          const logEntry = [
@@ -94,7 +97,7 @@ class Debugger {
     * @returns {void}
     */
    log(...params) {
-      if (this.logLevel === "INFO" || this.logLevel === "DEBUG" || this.logLevel === "") {
+      if (this.logLevel === "INFO" || this.logLevel === "DEBUG" || this.logLevel === undefined) {
          const logInfo = `[LOG] ${this.getTime()} | ${this.moduleInfo}`;
          const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
          const logEntry = [
@@ -161,7 +164,7 @@ class Debugger {
     * @returns {void}
     */
    debug(...params) {
-      if (this.logLevel === "" || this.logLevel === "DEBUG") {
+      if (this.logLevel === undefined || this.logLevel === "DEBUG") {
          const logInfo = `[DEBUG] ${this.getTime()} | ${this.moduleInfo}`;
          const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
          const logEntry = [
@@ -192,4 +195,4 @@ class Debugger {
 }
 // const logLevelSettingParam = getSetting("debug");
 // console.log(logLevelSettingParam);
-export const log = Object.freeze(new Debugger());
+export const log = new Debugger();

--- a/src/lib/debugger.js
+++ b/src/lib/debugger.js
@@ -1,41 +1,36 @@
-import { getSetting } from "../control/utilities";
-
 let instance;
 
-// /**
-//  * @enum {string}
-//  */
-// const logLevelStrings = {
-//    INFO: "INFO",
-//    ERROR: "ERORR",
-//    DEBUG: "DEBUG"
-// };
+/**
+ * @enum {string}
+ */
+const logLevelStrings = {
+   INFO: "INFO",
+   ERROR: "ERORR",
+   DEBUG: "DEBUG"
+};
 
 /**
- * @param {string} level
+ * @param {string} level - Takes INFO, ERROR, or DEBUG as arguments to set the logging level.
  *
- * @returns {logLevelStrings}
+ * @returns {logLevelStrings} - returns a log level validated to be accepted within the class.
  */
-// function validateLogLevel(level) {
-//    if (Object.values(logLevelStrings).includes(level)) {
-//       return level;
-//    }
-//    throw new Error(`Invalid log level: ${level}`);
-// }
+function validateLogLevel(level) {
+   if (Object.values(logLevelStrings).includes(level)) {
+      return level;
+   }
+   throw new Error(`Invalid log level: ${level}`);
+}
 
 class Debugger {
    /**
     * @class
-    *
-    * @param {import("../constants/settings").SettingsValue} logLevel - Accepts choices provided in Debug Setting "INFO"
-    * | "ERROR" | "DEBUG"
     */
-   constructor(logLevel) {
+   constructor() {
       if (instance) {
          throw new Error("Only one debugger class is allowed");
       }
       instance = this;
-      this.logLevel = logLevel;
+      this.logLevel = "";
       this.moduleInfo = "Knowledge Recalled:";
       this.sessionLog = [];
       this.count = {
@@ -47,6 +42,11 @@ class Debugger {
       };
    }
 
+   setLogLevel(logLevel) {
+      const validatedLogLevel = validateLogLevel(logLevel);
+      this.logLevel = validatedLogLevel;
+   }
+
    /**
     * @function
     *
@@ -55,14 +55,17 @@ class Debugger {
     * @returns {void}
     */
    info(...params) {
-      const logInfo = `[INFO] ${this.getTime()} | ${this.moduleInfo}`;
-      const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
-      const logEntry = [
-         logInfo, ...logObjects
-      ];
-      this.sessionLog.push(logEntry);
-      this.count.info++;
-      console.info(`[INFO] ${this.getTime()} | ${this.moduleInfo}`, ...params, this.count, this.sessionLog);
+      if (this.logLevel === "INFO" || this.logLevel === "DEBUG" || this.logLevel === "") {
+         const logInfo = `[INFO] ${this.getTime()} | ${this.moduleInfo}`;
+         const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
+         const logEntry = [
+            logInfo, ...logObjects
+         ];
+         this.sessionLog.push(logEntry);
+         this.count.info++;
+         console.info(`[INFO] ${this.getTime()} | ${this.moduleInfo}`, ...params, this.count, this.sessionLog);
+      }
+      return;
    }
 
    /**
@@ -91,14 +94,16 @@ class Debugger {
     * @returns {void}
     */
    log(...params) {
-      const logInfo = `[LOG] ${this.getTime()} | ${this.moduleInfo}`;
-      const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
-      const logEntry = [
-         logInfo, ...logObjects
-      ];
-      this.sessionLog.push(logEntry);
-      this.count.log++;
-      console.log(`[LOG] ${this.getTime()} | ${this.moduleInfo}`, ...params, this.count, this.sessionLog);
+      if (this.logLevel === "INFO" || this.logLevel === "DEBUG" || this.logLevel === "") {
+         const logInfo = `[LOG] ${this.getTime()} | ${this.moduleInfo}`;
+         const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
+         const logEntry = [
+            logInfo, ...logObjects
+         ];
+         this.sessionLog.push(logEntry);
+         this.count.log++;
+         console.log(`[LOG] ${this.getTime()} | ${this.moduleInfo}`, ...params, this.count, this.sessionLog);
+      }
    }
 
    /**
@@ -156,14 +161,16 @@ class Debugger {
     * @returns {void}
     */
    debug(...params) {
-      const logInfo = `[DEBUG] ${this.getTime()} | ${this.moduleInfo}`;
-      const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
-      const logEntry = [
-         logInfo, ...logObjects
-      ];
-      this.sessionLog.push(logEntry);
-      this.count.debug++;
-      console.debug(`[DEBUG] ${this.getTime()} | ${this.moduleInfo}`, ...params, this.count, this.sessionLog);
+      if (this.logLevel === "" || this.logLevel === "DEBUG") {
+         const logInfo = `[DEBUG] ${this.getTime()} | ${this.moduleInfo}`;
+         const logObjects = params.filter((param) => typeof param === 'object' || Array.isArray(param));
+         const logEntry = [
+            logInfo, ...logObjects
+         ];
+         this.sessionLog.push(logEntry);
+         this.count.debug++;
+         console.debug(`[DEBUG] ${this.getTime()} | ${this.moduleInfo}`, ...params, this.count, this.sessionLog);
+      }
    }
 
    /**
@@ -183,7 +190,6 @@ class Debugger {
 
 
 }
-
 // const logLevelSettingParam = getSetting("debug");
 // console.log(logLevelSettingParam);
 export const log = Object.freeze(new Debugger());

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,9 +1,16 @@
 import { SettingsShim } from "./view/settings/settingsApplication";
 
+import { getSetting } from "./control/utilities";
 import { CONSTANTS } from "./constants/constants";
 import { SETTINGS } from "./constants/settings";
+import { log } from "./lib/debugger";
 
-
+// TODO: https://discord.com/channels/737953117999726592/1089153493186662440
+// Let's migrate over to the TJS Settings
+// - We need SettingShim button
+// - settings App.js
+// - Svelte AppShell
+// - Largely implemented here: https://github.com/typhonjs-fvtt/mce-everywhere/blob/main/src/view/ConfigSettingApp.js
 /**
  *
  */
@@ -16,14 +23,18 @@ export function registerSettings() {
       icon: "fas fa-cog",
       type: SettingsShim,
       restricted: false
-   });
+   }
 
-   // FIXME: Error occuring here
+   );
+
    for (const [
       name, data
    ] of Object.entries(SETTINGS.GET_DEFAULT())) {
       game.settings.register(CONSTANTS.moduleId, name, data);
    }
+
+   const userLogLevel = getSetting("debug");
+   log.setLogLevel(userLogLevel);
 }
 
 /* FIXME:


### PR DESCRIPTION
Logging utility is stable, and is configurable from the settings menu. For development I recommend setting to DEBUG as this will provide the most verbose logging. ERROR shows the least and will only show errors, and INFO will provide everything except for DEBUG. Settings are also implemented, but the next release will have a newly reworked settings, and I will deprecate this that I currently have. The route I wish to go is more idiomatic of TyphonJS. See [MCE-Everywhere](https://github.com/typhonjs-fvtt/mce-everywhere), to see a model implementation.

I also fixed a bug that was causing the editor to default to absolute path imports, but relative is required for TyphonJS to compile the code. This is now resolved. 